### PR TITLE
fix inline create attribute value

### DIFF
--- a/product_configurator/models/product_attribute.py
+++ b/product_configurator/models/product_attribute.py
@@ -177,7 +177,8 @@ class ProductAttributeValue(models.Model):
         if self.env.context.get('product_tmpl_id'):
             # intercept already-created value
             product_tmpl_id = self.env.context.get('product_tmpl_id')
-            attribute_id = vals.get('attribute_id')
+            attribute_id = vals.get('attribute_id',
+                                    self.env.context.get('default_attribute_id'))
             line = self.env['product.attribute.line'].search([
                 ('product_tmpl_id', '=', product_tmpl_id),
                 ('attribute_id', '=', attribute_id)])


### PR DESCRIPTION
inline-create attribute value, use default_attribute_id.

Was popping the full create dialog.